### PR TITLE
Fix some syntax and consistency issues at `po.es`

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -127,7 +127,7 @@ msgstr "Actualización del parche"
 
 #: add-interactive.c:974 git-add--interactive.perl:1754
 msgid "Review diff"
-msgstr "Revisión de  diff"
+msgstr "Revisión de diff"
 
 #: add-interactive.c:1002
 msgid "show paths with changes"
@@ -143,11 +143,11 @@ msgstr "revertir conjunto de cambios en stage a la versión de HEAD"
 
 #: add-interactive.c:1008
 msgid "pick hunks and update selectively"
-msgstr "elegir hunks y actualizar de forma selectiva"
+msgstr "elegir fragmentos y actualizar de forma selectiva"
 
 #: add-interactive.c:1010
 msgid "view diff between HEAD and index"
-msgstr "ver diff entre HEAD e index"
+msgstr "ver diff entre HEAD e índice"
 
 #: add-interactive.c:1012
 msgid "add contents of untracked files to the staged set of changes"
@@ -168,7 +168,7 @@ msgstr "selecciona un rango de objetos"
 
 #: add-interactive.c:1026
 msgid "select multiple ranges"
-msgstr "selecciona multiples rangos"
+msgstr "selecciona múltiples rangos"
 
 #: add-interactive.c:1028 add-interactive.c:1073
 msgid "select item based on unique prefix"
@@ -222,7 +222,7 @@ msgstr "ruta"
 
 #: add-interactive.c:1143
 msgid "could not refresh index"
-msgstr "no se pudo refrescar el index"
+msgstr "no se pudo refrescar el índice"
 
 #: add-interactive.c:1157 builtin/clean.c:781 git-add--interactive.perl:1765
 #, c-format
@@ -242,14 +242,14 @@ msgstr "¿Aplicar stage al borrado [y,n,q,a,d%s,?]? "
 #: add-patch.c:36 git-add--interactive.perl:1430
 #, c-format, perl-format
 msgid "Stage this hunk [y,n,q,a,d%s,?]? "
-msgstr "¿Aplicar stage a este hunk [y,n,q,a,d%s,?]? "
+msgstr "¿Aplicar stage a este fragmento [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:38
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "staging."
 msgstr ""
-"Si el parche aplica limpiamente, el hunk editado sera marcado inmediatamente "
+"Si el parche aplica limpiamente, el fragmento editado será marcado inmediatamente "
 "para el área de stage."
 
 #: add-patch.c:41
@@ -260,11 +260,11 @@ msgid ""
 "a - stage this hunk and all later hunks in the file\n"
 "d - do not stage this hunk or any of the later hunks in the file\n"
 msgstr ""
-"y - aplicar stage a este hunk\n"
-"n - no aplicar stage a este hunk\n"
-"q - quit; no aplicar stage a este hunk o ninguno de los restantes\n"
-"a - aplicar stage a este hunk y a todos los posteriores en el archivo \n"
-"d - no aplicar stage a este hunk o a ninguno de los posteriores en este "
+"y - aplicar stage a este fragmento\n"
+"n - no aplicar stage a este fragmento\n"
+"q - quit; no aplicar stage a este fragmento o ninguno de los restantes\n"
+"a - aplicar stage a este fragmento y a todos los posteriores en el archivo \n"
+"d - no aplicar stage a este fragmento o a ninguno de los posteriores en este "
 "archivo\n"
 
 #: add-patch.c:55 git-add--interactive.perl:1433
@@ -280,14 +280,14 @@ msgstr "¿Aplicar stash al borrado [y,n,q,a,d%s,?]? "
 #: add-patch.c:57 git-add--interactive.perl:1435
 #, c-format, perl-format
 msgid "Stash this hunk [y,n,q,a,d%s,?]? "
-msgstr "¿Aplicar stash a este hunk [y,n,q,a,d%s,?]? "
+msgstr "¿Aplicar stash a este fragmento [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:59
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "stashing."
 msgstr ""
-"Si el parche aplica limpiamente, el hunk editado sera marcado inmediatamente "
+"Si el parche aplica limpiamente, el fragmento editado será marcado inmediatamente "
 "para aplicar stash."
 
 #: add-patch.c:62
@@ -298,11 +298,11 @@ msgid ""
 "a - stash this hunk and all later hunks in the file\n"
 "d - do not stash this hunk or any of the later hunks in the file\n"
 msgstr ""
-"y - aplicar stash a este hunk\n"
-"n - no aplicar stash a este hunk\n"
-"q - quit; no aplicar stash a este hunk o a ninguno de los restantes\n"
-"a - aplicar stash a este hunk y a todos los posteriores en el archivo\n"
-"d - no aplicar stash a este hunk o ninguno de los posteriores en el archivo\n"
+"y - aplicar stash a este fragmento\n"
+"n - no aplicar stash a este fragmento\n"
+"q - quit; no aplicar stash a este fragmento o a ninguno de los restantes\n"
+"a - aplicar stash a este fragmento y a todos los posteriores en el archivo\n"
+"d - no aplicar stash a este fragmento o ninguno de los posteriores en el archivo\n"
 
 #: add-patch.c:78 git-add--interactive.perl:1438
 #, c-format, perl-format
@@ -317,14 +317,14 @@ msgstr "¿Sacar borrado del stage [y,n,q,a,d%s,?]? "
 #: add-patch.c:80 git-add--interactive.perl:1440
 #, c-format, perl-format
 msgid "Unstage this hunk [y,n,q,a,d%s,?]? "
-msgstr "¿Sacar este hunk del stage [y,n,q,a,d%s,?]? "
+msgstr "¿Sacar este fragmento del stage [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:82
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "unstaging."
 msgstr ""
-"Si el parche aplica limpiamente, el hunk editado sera marcado inmediatamente "
+"Si el parche aplica limpiamente, el fragmento editado será marcado inmediatamente "
 "para sacar del área de stage."
 
 #: add-patch.c:85
@@ -335,11 +335,11 @@ msgid ""
 "a - unstage this hunk and all later hunks in the file\n"
 "d - do not unstage this hunk or any of the later hunks in the file\n"
 msgstr ""
-"y - sacar desde hunk del área de stage\n"
-"n - no sacar este hunk del area de stage\n"
-"q - quit; no sacar del area de stage este hunk o ninguno de los restantes\n"
-"a - sacar del area de stage este hunk y todos los posteriores en el archivo\n"
-"d - no sacar del area de stage este hunk o ninguno de los posteriores en el "
+"y - sacar desde fragmento del área de stage\n"
+"n - no sacar este fragmento del area de stage\n"
+"q - quit; no sacar del area de stage este fragmento o ninguno de los restantes\n"
+"a - sacar del area de stage este fragmento y todos los posteriores en el archivo\n"
+"d - no sacar del area de stage este fragmento o ninguno de los posteriores en el "
 "archivo\n"
 
 #: add-patch.c:100 git-add--interactive.perl:1443
@@ -355,14 +355,14 @@ msgstr "¿Aplicar borrado al índice [y,n,q,a,d%s,?]? "
 #: add-patch.c:102 git-add--interactive.perl:1445
 #, c-format, perl-format
 msgid "Apply this hunk to index [y,n,q,a,d%s,?]? "
-msgstr "¿Aplicar este hunk al índice [y,n,q,a,d%s,?]? "
+msgstr "¿Aplicar este fragmento al índice [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:104 add-patch.c:169 add-patch.c:212
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "applying."
 msgstr ""
-"Si el parche aplica de forma limpia, el hunk editado sera marcado "
+"Si el parche aplica de forma limpia, el fragmento editado será marcado "
 "inmediatamente para aplicar."
 
 #: add-patch.c:107
@@ -373,11 +373,11 @@ msgid ""
 "a - apply this hunk and all later hunks in the file\n"
 "d - do not apply this hunk or any of the later hunks in the file\n"
 msgstr ""
-"y - aplicar este hunk al índice\n"
-"n - no aplicar este hunk al índice\n"
-"q - quit; no aplicar este hunk o ninguno de los restantes\n"
-"a - aplicar este hunk y todos los posteriores en el archivo\n"
-"d - no aplicar este hunko ninguno de los posteriores en el archivo\n"
+"y - aplicar este fragmento al índice\n"
+"n - no aplicar este fragmento al índice\n"
+"q - quit; no aplicar este fragmento o ninguno de los restantes\n"
+"a - aplicar este fragmento y todos los posteriores en el archivo\n"
+"d - no aplicar este fragmentoo ninguno de los posteriores en el archivo\n"
 
 #: add-patch.c:122 git-add--interactive.perl:1448
 #: git-add--interactive.perl:1463
@@ -395,14 +395,14 @@ msgstr "¿Descartar borrado del árbol de trabajo [y,n,q,a,d%s,?]? "
 #: git-add--interactive.perl:1465
 #, c-format, perl-format
 msgid "Discard this hunk from worktree [y,n,q,a,d%s,?]? "
-msgstr "¿Descartar este hunk del árbol de trabajo [y,n,q,a,d%s,?]? "
+msgstr "¿Descartar este fragmento del árbol de trabajo [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:126 add-patch.c:148 add-patch.c:191
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "discarding."
 msgstr ""
-"Si el parche aplica de forma limpia, el hunk editado sera marcado "
+"Si el parche aplica de forma limpia, el fragmento editado será marcado "
 "inmediatamente para descarte."
 
 #: add-patch.c:129 add-patch.c:194
@@ -413,11 +413,11 @@ msgid ""
 "a - discard this hunk and all later hunks in the file\n"
 "d - do not discard this hunk or any of the later hunks in the file\n"
 msgstr ""
-"y - descartar este hunk del árbol de trabajo\n"
-"n - no descartar este hunk del árbol de trabajo\n"
-"q - quit; no descartar este hunk o ninguno de los que restantes\n"
-"a - descartar este hunk y todos los posteriores en este archivo\n"
-"d - no descartar este hunk o ninguno de los posteriores en el archivo\n"
+"y - descartar este fragmento del árbol de trabajo\n"
+"n - no descartar este fragmento del árbol de trabajo\n"
+"q - quit; no descartar este fragmento o ninguno de los que restantes\n"
+"a - descartar este fragmento y todos los posteriores en este archivo\n"
+"d - no descartar este fragmento o ninguno de los posteriores en el archivo\n"
 
 #: add-patch.c:144 add-patch.c:187 git-add--interactive.perl:1453
 #, c-format, perl-format
@@ -434,7 +434,7 @@ msgstr "¿Descartar borrado del índice y el árbol de trabajo [y,n,q,a,d%s,?]? 
 #, c-format, perl-format
 msgid "Discard this hunk from index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
-"¿Descartar este hunk del índice y el árbol de trabajo [y,n,q,a,d%s,?]? "
+"¿Descartar este fragmento del índice y el árbol de trabajo [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:151
 msgid ""
@@ -444,11 +444,11 @@ msgid ""
 "a - discard this hunk and all later hunks in the file\n"
 "d - do not discard this hunk or any of the later hunks in the file\n"
 msgstr ""
-"y - descartar este hunk del índice y el árbol de trabajo\n"
-"n - no descartar este hunk del índice ni el árbol de trabajo\n"
-"q - quit; no descartar este hunk o ninguno de los que quedan\n"
-"a - descartar este hunk y todos los posteriores en este archivo\n"
-"d - no descartar este hunk o ninguno posterior en el archivo\n"
+"y - descartar este fragmento del índice y el árbol de trabajo\n"
+"n - no descartar este fragmento del índice ni el árbol de trabajo\n"
+"q - quit; no descartar este fragmento o ninguno de los que quedan\n"
+"a - descartar este fragmento y todos los posteriores en este archivo\n"
+"d - no descartar este fragmento o ninguno posterior en el archivo\n"
 
 #: add-patch.c:165 add-patch.c:208 git-add--interactive.perl:1458
 #, c-format, perl-format
@@ -465,7 +465,7 @@ msgstr "¿Aplicar borrado al índice y al árbol de trabajo [y,n,q,a,d%s,?]? "
 #: add-patch.c:167 add-patch.c:210 git-add--interactive.perl:1460
 #, c-format, perl-format
 msgid "Apply this hunk to index and worktree [y,n,q,a,d%s,?]? "
-msgstr "¿Aplicar este hunk al índice y árbol de trabajo [y,n,q,a,d,/%s,?]? "
+msgstr "¿Aplicar este fragmento al índice y árbol de trabajo [y,n,q,a,d,/%s,?]? "
 
 #: add-patch.c:172
 msgid ""
@@ -475,11 +475,11 @@ msgid ""
 "a - apply this hunk and all later hunks in the file\n"
 "d - do not apply this hunk or any of the later hunks in the file\n"
 msgstr ""
-"y - aplicar este hunk al índice y al árbol de trabajo\n"
-"n - no aplicar este hunk al índice y al árbol de trabajo\n"
-"q - quit;  no aplicar este hunk o ninguno de los restantes\n"
-"a - aplicar este hunk y todos los posteriores en el archivo\n"
-"d - no aplicar este hunk o ninguno de los siguientes en este archivo\n"
+"y - aplicar este fragmento al índice y al árbol de trabajo\n"
+"n - no aplicar este fragmento al índice y al árbol de trabajo\n"
+"q - quit;  no aplicar este fragmento o ninguno de los restantes\n"
+"a - aplicar este fragmento y todos los posteriores en el archivo\n"
+"d - no aplicar este fragmento o ninguno de los siguientes en este archivo\n"
 
 #: add-patch.c:215
 msgid ""
@@ -489,21 +489,21 @@ msgid ""
 "a - apply this hunk and all later hunks in the file\n"
 "d - do not apply this hunk or any of the later hunks in the file\n"
 msgstr ""
-"y - aplicar este hunk al índice y al árbol de trabajo\n"
-"n - no aplicar este hunk al índice y al árbol de trabajo\n"
-"q - quit;  no aplicar este hunk o ninguno de los restantes\n"
-"a - aplicar este hunk y todos los posteriores en el archivo\n"
-"d - no aplicar este hunk o ninguno de los siguientes en este archivo\n"
+"y - aplicar este fragmento al índice y al árbol de trabajo\n"
+"n - no aplicar este fragmento al índice y al árbol de trabajo\n"
+"q - quit;  no aplicar este fragmento o ninguno de los restantes\n"
+"a - aplicar este fragmento y todos los posteriores en el archivo\n"
+"d - no aplicar este fragmento o ninguno de los siguientes en este archivo\n"
 
 #: add-patch.c:319
 #, c-format
 msgid "could not parse hunk header '%.*s'"
-msgstr "no se puede analizar hunk header '%.*s'"
+msgstr "no se puede analizar fragmento header '%.*s'"
 
 #: add-patch.c:338 add-patch.c:342
 #, c-format
 msgid "could not parse colored hunk header '%.*s'"
-msgstr "no se puede analizar hunk header '%.*s'"
+msgstr "no se puede analizar fragmento header '%.*s'"
 
 #: add-patch.c:396
 msgid "could not parse diff"
@@ -520,7 +520,7 @@ msgstr "falló al ejecutar '%s'"
 
 #: add-patch.c:588
 msgid "mismatched output from interactive.diffFilter"
-msgstr "output de interactive.diffFilter no concuerda"
+msgstr "salida de interactive.diffFilter no concuerda"
 
 #: add-patch.c:589
 msgid ""
@@ -547,14 +547,14 @@ msgid ""
 "\tdoes not end with:\n"
 "%.*s"
 msgstr ""
-"hunks no hacen overlap:\n"
+"fragmentos no se superponen:\n"
 "%.*s\n"
 "\tno acaba con:\n"
 "%.*s"
 
 #: add-patch.c:1053 git-add--interactive.perl:1112
 msgid "Manual hunk edit mode -- see bottom for a quick guide.\n"
-msgstr "Modo de edición manual de hunk -- vea abajo para una guía rápida.\n"
+msgstr "Modo de edición manual de fragmento -- vea abajo para una guía rápida.\n"
 
 #: add-patch.c:1057
 #, c-format
@@ -567,7 +567,7 @@ msgstr ""
 "---\n"
 "Para eliminar '%c' líneas, haga de ellas líneas  ' '  (contexto).\n"
 "Para eliminar '%c' líneas, bórrelas.\n"
-"Lineas comenzando con  %c serán eliminadas.\n"
+"Líneas comenzando con  %c serán eliminadas.\n"
 
 #. TRANSLATORS: 'it' refers to the patch mentioned in the previous messages.
 #: add-patch.c:1071 git-add--interactive.perl:1126
@@ -577,12 +577,12 @@ msgid ""
 "aborted and the hunk is left unchanged.\n"
 msgstr ""
 "Si esto no aplica de manera limpia, se te da la oportunidad de \n"
-"editar nuevamente. Si todas las líneas del hunk son eliminadas, entonces \n"
-"la edición es abortada y el hunk queda sin cambios.\n"
+"editar nuevamente. Si todas las líneas del fragmento son eliminadas, entonces \n"
+"la edición es abortada y el fragmento queda sin cambios.\n"
 
 #: add-patch.c:1104
 msgid "could not parse hunk header"
-msgstr "no se puede analizar hunk header"
+msgstr "no se puede analizar fragmento header"
 
 #: add-patch.c:1149
 msgid "'git apply --cached' failed"
@@ -604,12 +604,12 @@ msgstr "falló 'git apply --cached'"
 msgid ""
 "Your edited hunk does not apply. Edit again (saying \"no\" discards!) [y/n]? "
 msgstr ""
-"Tu hunk editado no aplica. ¿Editar nuevamente (¡decir \"no\" descarta!) [y/"
+"Tu fragmento editado no aplica. ¿Editar nuevamente (¡decir \"no\" descarta!) [y/"
 "n]? "
 
 #: add-patch.c:1261
 msgid "The selected hunks do not apply to the index!"
-msgstr "¡Los hunks seleccionados no aplican al índice!"
+msgstr "¡Los fragmentos seleccionados no aplican al índice!"
 
 #: add-patch.c:1262 git-add--interactive.perl:1343
 msgid "Apply them to the worktree anyway? "
@@ -631,40 +631,40 @@ msgid ""
 "e - manually edit the current hunk\n"
 "? - print help\n"
 msgstr ""
-"j - deja este hunk sin decidir, ver el siguiente hunk sin decisión\n"
-"J - deja este hunk sin decidir, ver siguiente hunk\n"
-"k - deja este hunk sin decidir, ver hunk previo sin decidir\n"
-"K - deja este hunk sin decidir, ver hunk anterior\n"
-"g - selecciona un hunk a dónde ir\n"
-"/ - buscar un hunk que cumpla con el regex dado\n"
-"s - separar el hunk actual en más pequeños\n"
-"e - editar manualmente el hunk actual\n"
+"j - deja este fragmento sin decidir, ver el siguiente fragmento sin decisión\n"
+"J - deja este fragmento sin decidir, ver siguiente fragmento\n"
+"k - deja este fragmento sin decidir, ver fragmento previo sin decidir\n"
+"K - deja este fragmento sin decidir, ver fragmento anterior\n"
+"g - selecciona un fragmento a dónde ir\n"
+"/ - buscar un fragmento que cumpla con el regex dado\n"
+"s - separar el fragmento actual en más pequeños\n"
+"e - editar manualmente el fragmento actual\n"
 "? - imprimir ayuda\n"
 
 #: add-patch.c:1447 add-patch.c:1457
 msgid "No previous hunk"
-msgstr "No el anterior hunk"
+msgstr "No hay fragmento anterior"
 
 #: add-patch.c:1452 add-patch.c:1462
 msgid "No next hunk"
-msgstr "No el siguiente hunk"
+msgstr "No hay fragmento siguiente"
 
 #: add-patch.c:1468
 msgid "No other hunks to goto"
-msgstr "No hay más pedazos para el ir"
+msgstr "No hay más fragmentos hacia donde ir"
 
 #: add-patch.c:1479 git-add--interactive.perl:1577
 msgid "go to which hunk (<ret> to see more)? "
-msgstr "¿a que hunk ir (<enter> para ver más)? "
+msgstr "¿a qué fragmento ir (<enter> para ver más)? "
 
 #: add-patch.c:1480 git-add--interactive.perl:1579
 msgid "go to which hunk? "
-msgstr "¿a que hunk ir? "
+msgstr "¿a qué fragmento ir? "
 
 #: add-patch.c:1491
 #, c-format
 msgid "Invalid number: '%s'"
-msgstr "Numero inválido: '%s'"
+msgstr "Número inválido: '%s'"
 
 #: add-patch.c:1496
 #, c-format
@@ -675,7 +675,7 @@ msgstr[1] "Lo siento, solo %d hunks disponibles."
 
 #: add-patch.c:1505
 msgid "No other hunks to search"
-msgstr "No hay más pedazos para buscar"
+msgstr "No hay más fragmentos para buscar"
 
 #: add-patch.c:1511 git-add--interactive.perl:1623
 msgid "search for regex? "
@@ -688,20 +688,20 @@ msgstr "Regexp para la búsqueda mal formado %s: %s"
 
 #: add-patch.c:1543
 msgid "No hunk matches the given pattern"
-msgstr "No hay hunks que concuerden con el patrón entregado."
+msgstr "No hay fragmentos que concuerden con el patrón entregado."
 
 #: add-patch.c:1550
 msgid "Sorry, cannot split this hunk"
-msgstr "Perdón, no se puede dividir este pedazo"
+msgstr "Perdón, no se puede dividir este fragmento"
 
 #: add-patch.c:1554
 #, c-format
 msgid "Split into %d hunks."
-msgstr "Cortar en %d hunk."
+msgstr "Cortar en %d fragmentos."
 
 #: add-patch.c:1558
 msgid "Sorry, cannot edit this hunk"
-msgstr "Perdón, no se puede editar este pedazo"
+msgstr "Perdón, no se puede editar este fragmento"
 
 #: add-patch.c:1609
 msgid "'git apply' failed"
@@ -873,21 +873,21 @@ msgstr ""
 msgid "git apply: bad git-diff - expected /dev/null, got %s on line %d"
 msgstr ""
 "git apply: git-diff erróneo - se esperaba /dev/null, se encontró %s en "
-"lalínea %d"
+"la línea %d"
 
 #: apply.c:928
 #, c-format
 msgid "git apply: bad git-diff - inconsistent new filename on line %d"
 msgstr ""
 "git apply: git-diff erróneo - nuevo nombre de archivo inconsistente en "
-"lalínea %d"
+"la línea %d"
 
 #: apply.c:929
 #, c-format
 msgid "git apply: bad git-diff - inconsistent old filename on line %d"
 msgstr ""
 "git apply: git-diff erróneo - viejo nombre de archivo inconsistente en "
-"lalínea %d"
+"la línea %d"
 
 #: apply.c:934
 #, c-format
@@ -1024,7 +1024,7 @@ msgstr "data perdida en parche binario para '%s'"
 #, c-format
 msgid "cannot reverse-apply a binary patch without the reverse hunk to '%s'"
 msgstr ""
-"no se puede revertir-aplicar un parche binario sin el hunk revertido a '%s'"
+"no se puede revertir-aplicar un parche binario sin el fragmento revertido a '%s'"
 
 #: apply.c:3152
 #, c-format
@@ -1355,7 +1355,7 @@ msgstr "en lugar de aplicar el parche, mostrar diffstat para la entrada"
 
 #: apply.c:4983
 msgid "show number of added and deleted lines in decimal notation"
-msgstr "mostrar el numero de líneas agregadas y eliminadas en notación decimal"
+msgstr "mostrar el número de líneas agregadas y eliminadas en notación decimal"
 
 #: apply.c:4985
 msgid "instead of applying the patch, output a summary for the input"
@@ -1429,11 +1429,11 @@ msgstr "no espera al menos una línea del contexto"
 
 #: apply.c:5022
 msgid "leave the rejected hunks in corresponding *.rej files"
-msgstr "dejar los hunks rechazados en los archivos *.rej correspontientes"
+msgstr "dejar los fragmentos rechazados en los archivos *.rej correspontientes"
 
 #: apply.c:5024
 msgid "allow overlapping hunks"
-msgstr "permitir solapamiento de hunks"
+msgstr "permitir solapamiento de fragmentos"
 
 #: apply.c:5025 builtin/add.c:323 builtin/check-ignore.c:22
 #: builtin/commit.c:1366 builtin/count-objects.c:98 builtin/fsck.c:774
@@ -1449,7 +1449,7 @@ msgstr ""
 
 #: apply.c:5030
 msgid "do not trust the line counts in the hunk headers"
-msgstr "no confiar en el conteo de líneas en los headers del hunk"
+msgstr "no confiar en el conteo de líneas en los headers del fragmento"
 
 #: apply.c:5032 builtin/am.c:2247
 msgid "root"
@@ -1683,8 +1683,8 @@ msgid ""
 "The merge base %s is bad.\n"
 "This means the bug has been fixed between %s and [%s].\n"
 msgstr ""
-"La base de fisión %s está mal.\n"
-"Esto quiere decir que el bug ha sido arreglado entre %s y [%s].\n"
+"La base de fusión %s está mal.\n"
+"Esto quiere decir que el bug ha sido corregido entre %s y [%s].\n"
 
 #: bisect.c:775
 #, c-format
@@ -1692,7 +1692,7 @@ msgid ""
 "The merge base %s is new.\n"
 "The property has changed between %s and [%s].\n"
 msgstr ""
-"La base de fisión %s es nueva.\n"
+"La base de fusión %s es nueva.\n"
 "Esta propiedad ha cambiado entre %s y [%s].\n"
 
 #: bisect.c:780
@@ -1701,7 +1701,7 @@ msgid ""
 "The merge base %s is %s.\n"
 "This means the first '%s' commit is between %s and [%s].\n"
 msgstr ""
-"La base de fisión %s es %s.\n"
+"La base de fusión %s es %s.\n"
 "Esto quiere decir que el primer '%s' commit está entre %s y [%s].\n"
 
 #: bisect.c:788
@@ -1729,7 +1729,7 @@ msgstr ""
 #: bisect.c:840
 #, c-format
 msgid "Bisecting: a merge base must be tested\n"
-msgstr "Biseccionando: una base de fisión debe ser probada\n"
+msgstr "Biseccionando: una base de fusión debe ser probada\n"
 
 #: bisect.c:890
 #, c-format
@@ -2082,16 +2082,16 @@ msgstr ""
 #: commit-graph.c:294
 #, c-format
 msgid "commit-graph improper chunk offset %08x%08x"
-msgstr "offset del chunk de commit-graph inapropiado %08x%08x"
+msgstr "offset del fragmento de commit-graph inapropiado %08x%08x"
 
 #: commit-graph.c:362
 #, c-format
 msgid "commit-graph chunk id %08x appears multiple times"
-msgstr "id de chunk de commit-graph %08x parece tener múltiples tiempos"
+msgstr "id de fragmento de commit-graph %08x parece tener múltiples tiempos"
 
 #: commit-graph.c:436
 msgid "commit-graph has no base graphs chunk"
-msgstr "commit-graph no tiene una chunk base de graphs"
+msgstr "commit-graph no tiene un fragmento base de graphs"
 
 #: commit-graph.c:446
 msgid "commit-graph chain does not match"
@@ -2868,7 +2868,7 @@ msgstr "Verificando conectividad"
 
 #: connected.c:119
 msgid "Could not run 'git rev-list'"
-msgstr "No se pudo correr 'git rev-list'"
+msgstr "No se pudo ejecutar 'git rev-list'"
 
 #: connected.c:139
 msgid "failed write to rev-list"
@@ -3551,7 +3551,7 @@ msgstr "ignora cambios cuyas líneas son todas en blanco"
 
 #: diff.c:5461
 msgid "heuristic to shift diff hunk boundaries for easy reading"
-msgstr "heurística para cambiar los límites de hunk para una fácil lectura"
+msgstr "heurística para cambiar los límites de fragmento para una fácil lectura"
 
 #: diff.c:5464
 msgid "generate diff using the \"patience diff\" algorithm"
@@ -3838,7 +3838,7 @@ msgstr "no se pudo configurar GIT_DIR a '%s'"
 #: exec-cmd.c:363
 #, c-format
 msgid "too many args to run %s"
-msgstr "demasiados argumentos para correr %s"
+msgstr "demasiados argumentos para ejecutar %s"
 
 #: fetch-pack.c:151
 msgid "git fetch-pack: expected shallow list"
@@ -4022,7 +4022,7 @@ msgstr "error procesando acks: %d"
 
 #: fetch-pack.c:1342
 msgid "expected packfile to be sent after 'ready'"
-msgstr "espere que el packfile sea mandado luego del 'listo'"
+msgstr "espere que el packfile sea enviado luego del 'listo'"
 
 #: fetch-pack.c:1344
 msgid "expected no other sections to be sent after no 'ready'"
@@ -4387,7 +4387,7 @@ msgid ""
 msgstr ""
 "No se puede crear '%s.lock': %s.\n"
 "\n"
-"Otro proceso git parece estar corriendo en el repositorio, es decir\n"
+"Otro proceso git parece estar ejecutándose en el repositorio, es decir\n"
 "un editor abierto con 'git commit'. Por favor asegúrese de que todos los "
 "procesos\n"
 "están terminados y vuelve a intentar. Si el fallo permanece, un proceso git\n"
@@ -4944,7 +4944,7 @@ msgstr "no hay archivos pack para indexar."
 
 #: midx.c:977
 msgid "Writing chunks to multi-pack-index"
-msgstr "Escribiendo chunks a multi-pack-index"
+msgstr "Escribiendo fragmentos a multi-pack-index"
 
 #: midx.c:1056
 #, c-format
@@ -5454,7 +5454,7 @@ msgstr "no es posible agregar '%s' al index"
 #: read-cache.c:805
 #, c-format
 msgid "unable to stat '%s'"
-msgstr "incapaz de correr stat en '%s'"
+msgstr "incapaz de ejecutar stat en '%s'"
 
 #: read-cache.c:1330
 #, c-format
@@ -5500,7 +5500,7 @@ msgstr "mala firma sha1 del archivo index"
 #: read-cache.c:1759
 #, c-format
 msgid "index uses %.4s extension, which we do not understand"
-msgstr "index usa %.4s extensiones, cosa que no entendemos"
+msgstr "índice usa %.4s extensiones, cosa que no entendemos"
 
 #: read-cache.c:1761
 #, c-format
@@ -5510,7 +5510,7 @@ msgstr "ignorando extensión %.4s"
 #: read-cache.c:1798
 #, c-format
 msgid "unknown index entry format 0x%08x"
-msgstr "formato de index desconocido 0x%08x"
+msgstr "formato de índice desconocido 0x%08x"
 
 #: read-cache.c:1814
 #, c-format
@@ -5519,7 +5519,7 @@ msgstr "campo nombre malformado en el index, cerca a ruta '%s'"
 
 #: read-cache.c:1871
 msgid "unordered stage entries in index"
-msgstr "entradas en stage desordenadas en index"
+msgstr "entradas en stage desordenadas en índice"
 
 #: read-cache.c:1874
 #, c-format
@@ -5553,22 +5553,22 @@ msgstr "no es posible unir hilo load_cache_entires: %s"
 #: read-cache.c:2170
 #, c-format
 msgid "%s: index file open failed"
-msgstr "%s: falló al abrir el archivo index"
+msgstr "%s: falló al abrir el archivo índice"
 
 #: read-cache.c:2174
 #, c-format
 msgid "%s: cannot stat the open index"
-msgstr "%s: no se puede hacer stat del index abierto"
+msgstr "%s: no se puede hacer stat del índice abierto"
 
 #: read-cache.c:2178
 #, c-format
 msgid "%s: index file smaller than expected"
-msgstr "%s: archivo index más pequeño de lo esperado"
+msgstr "%s: archivo índice más pequeño de lo esperado"
 
 #: read-cache.c:2182
 #, c-format
 msgid "%s: unable to map index file"
-msgstr "%s: no se pudo mapear el archivo index"
+msgstr "%s: no se pudo mapear el archivo índice"
 
 #: read-cache.c:2224
 #, c-format
@@ -5583,12 +5583,12 @@ msgstr "no es posible unir hilo load_index_extensions: %s"
 #: read-cache.c:2283
 #, c-format
 msgid "could not freshen shared index '%s'"
-msgstr "no se pudo refrescar el index compartido '%s'"
+msgstr "no se pudo refrescar el índice compartido '%s'"
 
 #: read-cache.c:2330
 #, c-format
 msgid "broken index, expect %s in %s, got %s"
-msgstr "index roto, se esperaba %s en %s, se obtuvo %s"
+msgstr "índice roto, se esperaba %s en %s, se obtuvo %s"
 
 #: read-cache.c:3026 strbuf.c:1176 wrapper.c:622 builtin/merge.c:1130
 #, c-format
@@ -5971,7 +5971,7 @@ msgstr "(o hay rama, rebasando con HEAD desacoplado %s"
 #: ref-filter.c:1492
 #, c-format
 msgid "no branch, bisect started on %s"
-msgstr "no hay rama, comenzando biseccón en  %s"
+msgstr "no hay rama, comenzando biseccón en %s"
 
 #: ref-filter.c:1502
 msgid "no branch"
@@ -6447,7 +6447,7 @@ msgstr "falló al hacer flush '%s'"
 #: rerere.c:503 rerere.c:1039
 #, c-format
 msgid "could not parse conflict hunks in '%s'"
-msgstr "no se pudo analizar hunks en conflicto en '%s'"
+msgstr "no se pudo analizar fragmentos en conflicto en '%s'"
 
 #: rerere.c:684
 #, c-format
@@ -6592,7 +6592,7 @@ msgid ""
 "not sending a push certificate since the receiving end does not support --"
 "signed push"
 msgstr ""
-"no se manda un certificado de push ya que el destino no soporta push firmado "
+"no se envía un certificado de push ya que el destino no soporta push firmado "
 "(--signed )"
 
 #: send-pack.c:413
@@ -7035,7 +7035,7 @@ msgstr "línea inválida %d: %.*s"
 #: sequencer.c:2226
 #, c-format
 msgid "cannot '%s' without a previous commit"
-msgstr "no se puede  '%s' sin un commit previo"
+msgstr "no se puede '%s' sin un commit previo"
 
 #: sequencer.c:2310
 msgid "cancelling a cherry picking in progress"
@@ -7563,7 +7563,7 @@ msgstr "esta operación debe ser realizada en un árbol de trabajo"
 #: setup.c:569
 #, c-format
 msgid "Expected git repo version <= %d, found %d"
-msgstr "Se esperaba versión de git repo  <= %d, encontrada %d"
+msgstr "Se esperaba versión de git repo <= %d, encontrada %d"
 
 #: setup.c:577
 msgid "unknown repository extensions found:"
@@ -7750,12 +7750,12 @@ msgstr "archivo de objeto %s está vacío"
 #: sha1-file.c:1274 sha1-file.c:2454
 #, c-format
 msgid "corrupt loose object '%s'"
-msgstr "objeto perdido corrupto '%s'"
+msgstr "objeto suelto corrupto '%s'"
 
 #: sha1-file.c:1276 sha1-file.c:2458
 #, c-format
 msgid "garbage at end of loose object '%s'"
-msgstr "basura al final del objeto perdido '%s'"
+msgstr "basura al final del objeto suelto '%s'"
 
 #: sha1-file.c:1318
 msgid "invalid object type"
@@ -7794,7 +7794,7 @@ msgstr "reemplazo %s no encontrado para %s"
 #: sha1-file.c:1648
 #, c-format
 msgid "loose object %s (stored in %s) is corrupt"
-msgstr "objeto perdido %s (guardado en %s) está corrompido"
+msgstr "objeto suelto %s (guardado en %s) está corrompido"
 
 #: sha1-file.c:1652
 #, c-format
@@ -8009,12 +8009,12 @@ msgstr ""
 #: sha1-name.c:1756
 #, c-format
 msgid "path '%s' exists on disk, but not in the index"
-msgstr "ruta '%s' existe en el disco, pero no en el index"
+msgstr "ruta '%s' existe en el disco, pero no en el índice"
 
 #: sha1-name.c:1758
 #, c-format
 msgid "path '%s' does not exist (neither on disk nor in the index)"
-msgstr "ruta '%s' no existe (ni en disco ni en el index)"
+msgstr "ruta '%s' no existe (ni en disco ni en el índice)"
 
 #: sha1-name.c:1771
 msgid "relative path syntax can't be used outside working tree"
@@ -8241,7 +8241,7 @@ msgstr "no pudo recursar en el submódulo '%s'"
 
 #: submodule.c:1876
 msgid "could not reset submodule index"
-msgstr "no se pudo reiniciar el index del submódulo"
+msgstr "no se pudo reiniciar el índice del submódulo"
 
 #: submodule.c:1918
 #, c-format
@@ -8256,7 +8256,7 @@ msgstr "Submódulo '%s' no pudo ser actualizado."
 #: submodule.c:2038
 #, c-format
 msgid "submodule git dir '%s' is inside git dir '%.*s'"
-msgstr "submódulo git dir '%s' esta dentro de git dir '%.*s'"
+msgstr "submódulo git dir '%s' está dentro de git dir '%.*s'"
 
 #: submodule.c:2059
 #, c-format
@@ -8898,7 +8898,7 @@ msgstr ""
 
 #: unpack-trees.c:1498
 msgid "Updating index flags"
-msgstr "Actualizando flags del index"
+msgstr "Actualizando flags del índice"
 
 #: upload-pack.c:1337
 msgid "expected flush after fetch arguments"
@@ -8927,7 +8927,7 @@ msgstr "carácter inválido en el nombre del host"
 
 #: urlmatch.c:292 urlmatch.c:303
 msgid "invalid port number"
-msgstr "numero de puerto inválido"
+msgstr "número de puerto inválido"
 
 #: urlmatch.c:371
 msgid "invalid '..' path segment"
@@ -9591,7 +9591,7 @@ msgstr "selección interactiva"
 
 #: builtin/add.c:326 builtin/checkout.c:1535 builtin/reset.c:308
 msgid "select hunks interactively"
-msgstr "elegir hunks de forma interactiva"
+msgstr "elegir fragmentos de forma interactiva"
 
 #: builtin/add.c:327
 msgid "edit current diff and apply"
@@ -9670,7 +9670,7 @@ msgstr ""
 "\n"
 "\tgit submodule add <url> %s\n"
 "\n"
-"Si se agrego esta ruta por error, puedes eliminar desde el índice \n"
+"Si se agregó esta ruta por error, puedes eliminar desde el índice \n"
 "usando:\n"
 "\n"
 "\tgit rm --cached %s\n"
@@ -9819,7 +9819,7 @@ msgstr ""
 #: builtin/am.c:1174
 msgid "Patch sent with format=flowed; space at the end of lines might be lost."
 msgstr ""
-"Parche mandado con formato=flowed; espacios al final de las líneas tal vez "
+"Parche enviado con formato=flowed; espacios al final de las líneas tal vez "
 "desaparezcan."
 
 #: builtin/am.c:1202
@@ -11307,7 +11307,7 @@ msgstr "copiar los archivos del stage nombrado"
 
 #: builtin/checkout.c:31
 msgid "git checkout [<options>] <branch>"
-msgstr "git checkout [<opciones>]  <rama>"
+msgstr "git checkout [<opciones>] <rama>"
 
 #: builtin/checkout.c:32
 msgid "git checkout [<options>] [<branch>] -- <file>..."
@@ -11406,7 +11406,7 @@ msgstr "'%s' o '%s' no puede ser usado con %s"
 #: builtin/checkout.c:527 builtin/checkout.c:534
 #, c-format
 msgid "path '%s' is unmerged"
-msgstr "ruta '%s' no esta fusionada"
+msgstr "ruta '%s' no está fusionada"
 
 #: builtin/checkout.c:704
 msgid "you need to resolve your current index first"
@@ -11432,7 +11432,7 @@ msgstr "HEAD está ahora en"
 
 #: builtin/checkout.c:907 builtin/clone.c:720
 msgid "unable to update HEAD"
-msgstr "no es posible actualizar  HEAD"
+msgstr "no es posible actualizar HEAD"
 
 #: builtin/checkout.c:911
 #, c-format
@@ -11559,7 +11559,7 @@ msgstr ""
 #: builtin/checkout.c:1169
 #, c-format
 msgid "'%s' matched multiple (%d) remote tracking branches"
-msgstr "'%s' concordó con multiples (%d) ramas de rastreo remoto"
+msgstr "'%s' concordó con múltiples (%d) ramas de rastreo remoto"
 
 #: builtin/checkout.c:1235
 msgid "only one reference expected"
@@ -11722,7 +11722,7 @@ msgstr "no revise si otro árbol de trabajo contiene la ref entregada"
 
 #: builtin/checkout.c:1530
 msgid "checkout our version for unmerged files"
-msgstr "hacer checkout a  nuestra versión para archivos sin fusionar"
+msgstr "hacer checkout a nuestra versión para archivos sin fusionar"
 
 #: builtin/checkout.c:1533
 msgid "checkout their version for unmerged files"
@@ -11837,7 +11837,7 @@ msgstr "de qué árbol hacer el checkout"
 
 #: builtin/checkout.c:1845
 msgid "restore the index"
-msgstr "restaurar el index"
+msgstr "restaurar el índice"
 
 #: builtin/checkout.c:1847
 msgid "restore the working tree (default)"
@@ -11896,7 +11896,7 @@ msgid ""
 "           - (empty) select nothing\n"
 msgstr ""
 "Ayuda rápida:\n"
-"1          - selecciona un objeto por numero\n"
+"1          - selecciona un objeto por número\n"
 "foo        - selecciona un objeto basado en un prefijo único\n"
 "           - (vacío) no elegir nada\n"
 
@@ -11959,7 +11959,7 @@ msgid ""
 msgstr ""
 "clean               - comenzar la limpieza\n"
 "filtrar por patrón   - excluye objetos del borrado \n"
-"elegir por números   - selecciona objetos a ser borrados por numero\n"
+"elegir por números   - selecciona objetos a ser borrados por número\n"
 "preguntar cada uno     - confirmar cada borrado (como \"rm -i\")\n"
 "quit                - parar limpieza\n"
 "help                - esta ventana\n"
@@ -12068,7 +12068,7 @@ msgstr "inicializar submódulos en el clonado"
 
 #: builtin/clone.c:110
 msgid "number of submodules cloned in parallel"
-msgstr "numero de submódulos clonados en paralelo"
+msgstr "número de submódulos clonados en paralelo"
 
 #: builtin/clone.c:111 builtin/init-db.c:533
 msgid "template-directory"
@@ -12086,7 +12086,7 @@ msgstr "repositorio de referencia"
 #: builtin/clone.c:118 builtin/submodule--helper.c:1409
 #: builtin/submodule--helper.c:1914
 msgid "use --reference only while cloning"
-msgstr "usa--reference  solamente si estás clonado"
+msgstr "usa--reference solamente si estás clonado"
 
 #: builtin/clone.c:119 builtin/column.c:27 builtin/merge-file.c:46
 #: builtin/pack-objects.c:3442 builtin/repack.c:329
@@ -12303,7 +12303,7 @@ msgstr "repositorio '%s' no existe"
 #: builtin/clone.c:1010 builtin/fetch.c:1789
 #, c-format
 msgid "depth %s is not a positive number"
-msgstr "profundidad %s no es un numero positivo"
+msgstr "profundidad %s no es un número positivo"
 
 #: builtin/clone.c:1020
 #, c-format
@@ -12900,7 +12900,7 @@ msgstr "calcular todos los valores delante/atrás"
 
 #: builtin/commit.c:1376
 msgid "version"
-msgstr "version"
+msgstr "versión"
 
 #: builtin/commit.c:1376 builtin/commit.c:1535 builtin/push.c:549
 #: builtin/worktree.c:646
@@ -13243,7 +13243,7 @@ msgstr "valor es \"true\" o \"false\""
 
 #: builtin/config.c:150
 msgid "value is decimal number"
-msgstr "valor es un numero decimal"
+msgstr "valor es un número decimal"
 
 #: builtin/config.c:151
 msgid "value is --bool or --int"
@@ -13369,7 +13369,7 @@ msgid ""
 "extension worktreeConfig is enabled. Please read \"CONFIGURATION FILE\"\n"
 "section in \"git help worktree\" for details"
 msgstr ""
-"--worktree no puede ser usado con multiples árboles de trabajo a menos que "
+"--worktree no puede ser usado con múltiples árboles de trabajo a menos que "
 "la\n"
 "extensión worktreeConfig esté habilitada. Por favor lea \"CONFIGURATION FILE"
 "\"\n"
@@ -14686,7 +14686,7 @@ msgstr "no hay soporte para hilos, ignorando %s"
 #: builtin/grep.c:475 builtin/grep.c:600 builtin/grep.c:640
 #, c-format
 msgid "unable to read tree (%s)"
-msgstr "no es posible leer el  árbol (%s)"
+msgstr "no es posible leer el árbol (%s)"
 
 #: builtin/grep.c:655
 #, c-format
@@ -14748,7 +14748,7 @@ msgstr "buscar en subdirectorios (default)"
 
 #: builtin/grep.c:849
 msgid "descend at most <depth> levels"
-msgstr "descender como máximo <valor-de-profundiad>  niveles"
+msgstr "descender como máximo <valor-de-profundiad> niveles"
 
 #: builtin/grep.c:853
 msgid "use extended POSIX regular expressions"
@@ -14760,7 +14760,7 @@ msgstr "usar expresiones regulares POSIX (default)"
 
 #: builtin/grep.c:859
 msgid "interpret patterns as fixed strings"
-msgstr "interpretar patrones como strings arreglados"
+msgstr "interpretar patrones como cadenas literales"
 
 #: builtin/grep.c:862
 msgid "use Perl-compatible regular expressions"
@@ -14888,7 +14888,7 @@ msgstr "mostrar archivos concordantes en el paginador"
 
 #: builtin/grep.c:936
 msgid "allow calling of grep(1) (ignored by this build)"
-msgstr "permitir el llamado de grep(1) (ignorado por esta build)"
+msgstr "permitir el llamado de grep(1) (ignorado por este build)"
 
 #: builtin/grep.c:1003
 msgid "no pattern given"
@@ -16227,7 +16227,7 @@ msgstr ""
 
 #: builtin/merge-file.c:35
 msgid "send results to standard output"
-msgstr "mandar resultados a standard output"
+msgstr "enviar resultados a standard output"
 
 #: builtin/merge-file.c:36
 msgid "use a diff3 based merge"
@@ -16525,7 +16525,7 @@ msgstr "No hay remoto para la rama actual."
 
 #: builtin/merge.c:992
 msgid "No default upstream defined for the current branch."
-msgstr "Por defecto, no hay un upstream  definido para la rama actual."
+msgstr "Por defecto, no hay un upstream definido para la rama actual."
 
 #: builtin/merge.c:997
 #, c-format
@@ -17424,11 +17424,11 @@ msgstr "no se puede abrir índice de paquetes"
 #: builtin/pack-objects.c:3083
 #, c-format
 msgid "loose object at %s could not be examined"
-msgstr "objeto perdido en %s no pudo ser examinado"
+msgstr "objeto suelto en %s no pudo ser examinado"
 
 #: builtin/pack-objects.c:3168
 msgid "unable to force loose object"
-msgstr "incapaz de forzar un objeto perdido"
+msgstr "incapaz de forzar un objeto suelto"
 
 #: builtin/pack-objects.c:3261
 #, c-format
@@ -17655,7 +17655,7 @@ msgstr "empaquetar todo"
 
 #: builtin/pack-refs.c:17
 msgid "prune loose refs (default)"
-msgstr "recortar refs perdidos (default)"
+msgstr "recortar refs sueltos (default)"
 
 #: builtin/prune-packed.c:6
 msgid "git prune-packed [-n | --dry-run] [-q | --quiet]"
@@ -19819,7 +19819,7 @@ msgstr "mktree no devolvió un nombre de objeto"
 #: builtin/replace.c:298
 #, c-format
 msgid "unable to fstat %s"
-msgstr "incapaz de correr fstat %s"
+msgstr "incapaz de ejecutar fstat %s"
 
 #: builtin/replace.c:303
 msgid "unable to write object to database"
@@ -20048,7 +20048,7 @@ msgstr "HEAD está ahora en %s"
 #: builtin/reset.c:195
 #, c-format
 msgid "Cannot do a %s reset in the middle of a merge."
-msgstr "No se puede realziar un reset %s  en medio de una fusión."
+msgstr "No se puede realziar un reset %s en medio de una fusión."
 
 #: builtin/reset.c:295 builtin/stash.c:520 builtin/stash.c:595
 #: builtin/stash.c:619
@@ -20057,7 +20057,7 @@ msgstr "ser silencioso, solo reportar errores"
 
 #: builtin/reset.c:297
 msgid "reset HEAD and index"
-msgstr "reiniciar HEAD e index"
+msgstr "reiniciar HEAD e índice"
 
 #: builtin/reset.c:298
 msgid "reset only HEAD"
@@ -20776,7 +20776,7 @@ msgstr "El índice no fue sacado de stash."
 
 #: builtin/stash.c:522 builtin/stash.c:621
 msgid "attempt to recreate the index"
-msgstr "intento de recrear el index"
+msgstr "intento de recrear el índice"
 
 #: builtin/stash.c:555
 #, c-format
@@ -20869,7 +20869,7 @@ msgstr "No se pueden eliminar cambios del árbol de trabajo"
 
 #: builtin/stash.c:1466 builtin/stash.c:1531
 msgid "keep index"
-msgstr "mantener index"
+msgstr "mantener índice"
 
 #: builtin/stash.c:1468 builtin/stash.c:1533
 msgid "stash in patch mode"
@@ -21591,7 +21591,7 @@ msgstr "opción --points-at solo es permitida en modo lista"
 
 #: builtin/tag.c:513
 msgid "--merged and --no-merged options are only allowed in list mode"
-msgstr "opciones --merged y --no-merged  solo están permitidas en modo lista"
+msgstr "opciones --merged y --no-merged solo están permitidas en modo lista"
 
 #: builtin/tag.c:524
 msgid "only one -F or -m option is allowed."
@@ -22273,7 +22273,7 @@ msgstr "<prefijo>/"
 
 #: builtin/write-tree.c:29
 msgid "write tree object for a subdirectory <prefix>"
-msgstr "escribir objeto de  árbol para un subdirectorio <prefijo>"
+msgstr "escribir objeto de árbol para un subdirectorio <prefijo>"
 
 #: builtin/write-tree.c:31
 msgid "only useful for debugging"
@@ -22411,7 +22411,7 @@ msgid ""
 "\n"
 "\tchmod 0700 %s"
 msgstr ""
-"Los permisos en tu directorio de socket son demasiado flojos; otros\n"
+"Los permisos en tu directorio de socket son demasiado amplios; otros\n"
 "usuarios pueden leer sus credenciales almacenadas en caché. Considera "
 "ejecutar:\n"
 "\n"
@@ -22816,7 +22816,7 @@ msgstr "Anotar líneas de archivo con información de commit"
 
 #: command-list.h:53
 msgid "Apply a patch to files and/or to the index"
-msgstr "Aplicar un parche a archivos y/o  el índice"
+msgstr "Aplicar un parche a archivos y/o el índice"
 
 #: command-list.h:54
 msgid "Import a GNU Arch repository into Git"
@@ -23931,7 +23931,7 @@ msgstr "Este es el mensaje del commit #${n}:"
 #: git-rebase--preserve-merges.sh:472
 #, sh-format
 msgid "The commit message #${n} will be skipped:"
-msgstr "El mensaje del commit  #${n} será ignorado:"
+msgstr "El mensaje del commit #${n} será ignorado:"
 
 #: git-rebase--preserve-merges.sh:483
 #, sh-format
@@ -24212,7 +24212,7 @@ msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be\n"
 "marked for staging."
 msgstr ""
-"Si el parche aplica limpiamente, el hunk editado sera marcado\n"
+"Si el parche aplica limpiamente, el fragmento editado será marcado\n"
 "inmediatamente para el área de stage."
 
 #: git-add--interactive.perl:1056
@@ -24220,7 +24220,7 @@ msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be\n"
 "marked for stashing."
 msgstr ""
-"Si el parche aplica limpiamente, el hunk editado sera marcado\n"
+"Si el parche aplica limpiamente, el fragmento editado será marcado\n"
 "inmediatamente para aplicar stash."
 
 #: git-add--interactive.perl:1059
@@ -24228,7 +24228,7 @@ msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be\n"
 "marked for unstaging."
 msgstr ""
-"Si el parche aplica limpiamente, el hunk editado sera marcado\n"
+"Si el parche aplica limpiamente, el fragmento editado será marcado\n"
 "inmediatamente para sacar del área de stage."
 
 #: git-add--interactive.perl:1062 git-add--interactive.perl:1071
@@ -24237,7 +24237,7 @@ msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be\n"
 "marked for applying."
 msgstr ""
-"Si el parche aplica de forma limpia, el hunk editado sera marcado \n"
+"Si el parche aplica de forma limpia, el fragmento editado será marcado \n"
 "inmediatamente para aplicar."
 
 #: git-add--interactive.perl:1065 git-add--interactive.perl:1068
@@ -24246,13 +24246,13 @@ msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be\n"
 "marked for discarding."
 msgstr ""
-"Si el parche aplica de forma limpia, el hunk editado sera marcado\n"
+"Si el parche aplica de forma limpia, el fragmento editado será marcado\n"
 "inmediatamente para descarte."
 
 #: git-add--interactive.perl:1111
 #, perl-format
 msgid "failed to open hunk edit file for writing: %s"
-msgstr "falló al abrir el archivo de adición del hunk para escritura: %s"
+msgstr "falló al abrir el archivo de adición del fragmento para escritura: %s"
 
 #: git-add--interactive.perl:1118
 #, perl-format
@@ -24270,7 +24270,7 @@ msgstr ""
 #: git-add--interactive.perl:1140
 #, perl-format
 msgid "failed to open hunk edit file for reading: %s"
-msgstr "falló al abrir el archivo de edición del hunk para lectura: %s"
+msgstr "falló al abrir el archivo de edición del fragmento para lectura: %s"
 
 #: git-add--interactive.perl:1248
 msgid ""
@@ -24280,11 +24280,11 @@ msgid ""
 "a - stage this hunk and all later hunks in the file\n"
 "d - do not stage this hunk or any of the later hunks in the file"
 msgstr ""
-"y - aplicar stage a este hunk\n"
-"n - no aplicar stage a este hunk\n"
-"q - quit; no aplicar stage a este hunk o ninguno de los restantes\n"
-"a - aplicar stage a este hunk y a todos los posteriores en el archivo \n"
-"d - no aplicar stage a este hunk o a ninguno de los posteriores en este "
+"y - aplicar stage a este fragmento\n"
+"n - no aplicar stage a este fragmento\n"
+"q - quit; no aplicar stage a este fragmento o ninguno de los restantes\n"
+"a - aplicar stage a este fragmento y a todos los posteriores en el archivo \n"
+"d - no aplicar stage a este fragmento o a ninguno de los posteriores en este "
 "archivo"
 
 #: git-add--interactive.perl:1254
@@ -24295,11 +24295,11 @@ msgid ""
 "a - stash this hunk and all later hunks in the file\n"
 "d - do not stash this hunk or any of the later hunks in the file"
 msgstr ""
-"y - aplicar stash a este hunk\n"
-"n - no aplicar stash a este hunk\n"
-"q - quit; no aplicar stash a este hunk o a ninguno de los restantes\n"
-"a - aplicar stash a este hunk y a todos los posteriores en el archivo\n"
-"d - no aplicar stash a este hunk o ninguno de los posteriores en el archivo"
+"y - aplicar stash a este fragmento\n"
+"n - no aplicar stash a este fragmento\n"
+"q - quit; no aplicar stash a este fragmento o a ninguno de los restantes\n"
+"a - aplicar stash a este fragmento y a todos los posteriores en el archivo\n"
+"d - no aplicar stash a este fragmento o ninguno de los posteriores en el archivo"
 
 #: git-add--interactive.perl:1260
 msgid ""
@@ -24309,11 +24309,11 @@ msgid ""
 "a - unstage this hunk and all later hunks in the file\n"
 "d - do not unstage this hunk or any of the later hunks in the file"
 msgstr ""
-"y - sacar desde hunk del área de stage\n"
-"n - no sacar este hunk del area de stage\n"
-"q - quit; no sacar del area de stage este hunk o ninguno de los restantes\n"
-"a - sacar del area de stage este hunk y todos los posteriores en el archivo\n"
-"d - no sacar del area de stage este hunk o ninguno de los posteriores en el "
+"y - sacar desde fragmento del área de stage\n"
+"n - no sacar este fragmento del area de stage\n"
+"q - quit; no sacar del area de stage este fragmento o ninguno de los restantes\n"
+"a - sacar del area de stage este fragmento y todos los posteriores en el archivo\n"
+"d - no sacar del area de stage este fragmento o ninguno de los posteriores en el "
 "archivo"
 
 #: git-add--interactive.perl:1266
@@ -24324,11 +24324,11 @@ msgid ""
 "a - apply this hunk and all later hunks in the file\n"
 "d - do not apply this hunk or any of the later hunks in the file"
 msgstr ""
-"y - aplicar este hunk al índice\n"
-"n - no aplicar este hunk al índice\n"
-"q - quit; no aplicar este hunk o ninguno de los restantes\n"
-"a - aplicar este hunk y todos los posteriores en el archivo\n"
-"d - no aplicar este hunko ninguno de los posteriores en el archivo"
+"y - aplicar este fragmento al índice\n"
+"n - no aplicar este fragmento al índice\n"
+"q - quit; no aplicar este fragmento o ninguno de los restantes\n"
+"a - aplicar este fragmento y todos los posteriores en el archivo\n"
+"d - no aplicar este fragmentoo ninguno de los posteriores en el archivo"
 
 #: git-add--interactive.perl:1272 git-add--interactive.perl:1290
 msgid ""
@@ -24338,11 +24338,11 @@ msgid ""
 "a - discard this hunk and all later hunks in the file\n"
 "d - do not discard this hunk or any of the later hunks in the file"
 msgstr ""
-"y - descartar este hunk del árbol de trabajo\n"
-"n - no descartar este hunk del árbol de trabajo\n"
-"q - quit; no descartar este hunk o ninguno de los que restantes\n"
-"a - descartar este hunk y todos los posteriores en este archivo\n"
-"d - no descartar este hunk o ninguno de los posteriores en el archivo"
+"y - descartar este fragmento del árbol de trabajo\n"
+"n - no descartar este fragmento del árbol de trabajo\n"
+"q - quit; no descartar este fragmento o ninguno de los que restantes\n"
+"a - descartar este fragmento y todos los posteriores en este archivo\n"
+"d - no descartar este fragmento o ninguno de los posteriores en el archivo"
 
 #: git-add--interactive.perl:1278
 msgid ""
@@ -24352,11 +24352,11 @@ msgid ""
 "a - discard this hunk and all later hunks in the file\n"
 "d - do not discard this hunk or any of the later hunks in the file"
 msgstr ""
-"y - descartar este hunk del índice y el árbol de trabajo\n"
-"n - no descartar este hunk del índice ni el árbol de trabajo\n"
-"q - quit; no descartar este hunk o ninguno de los que quedan\n"
-"a - descartar este hunk y todos los posteriores en este archivo\n"
-"d - no descartar este hunk o ninguno posterior en el archivo"
+"y - descartar este fragmento del índice y el árbol de trabajo\n"
+"n - no descartar este fragmento del índice ni el árbol de trabajo\n"
+"q - quit; no descartar este fragmento o ninguno de los que quedan\n"
+"a - descartar este fragmento y todos los posteriores en este archivo\n"
+"d - no descartar este fragmento o ninguno posterior en el archivo"
 
 #: git-add--interactive.perl:1284
 msgid ""
@@ -24366,11 +24366,11 @@ msgid ""
 "a - apply this hunk and all later hunks in the file\n"
 "d - do not apply this hunk or any of the later hunks in the file"
 msgstr ""
-"y - aplicar este hunk al índice y al árbol de trabajo\n"
-"n - no aplicar este hunk al índice y al árbol de trabajo\n"
-"q - quit;  no aplicar este hunk o ninguno de los restantes\n"
-"a - aplicar este hunk y todos los posteriores en el archivo\n"
-"d - no aplicar este hunk o ninguno de los siguientes en este archivo"
+"y - aplicar este fragmento al índice y al árbol de trabajo\n"
+"n - no aplicar este fragmento al índice y al árbol de trabajo\n"
+"q - quit;  no aplicar este fragmento o ninguno de los restantes\n"
+"a - aplicar este fragmento y todos los posteriores en el archivo\n"
+"d - no aplicar este fragmento o ninguno de los siguientes en este archivo"
 
 #: git-add--interactive.perl:1296
 msgid ""
@@ -24380,11 +24380,11 @@ msgid ""
 "a - apply this hunk and all later hunks in the file\n"
 "d - do not apply this hunk or any of the later hunks in the file"
 msgstr ""
-"y - aplicar este hunk al índice y al árbol de trabajo\n"
-"n - no aplicar este hunk al índice y al árbol de trabajo\n"
-"q - quit;  no aplicar este hunk o ninguno de los restantes\n"
-"a - aplicar este hunk y todos los posteriores en el archivo\n"
-"d - no aplicar este hunk o ninguno de los siguientes en este archivo"
+"y - aplicar este fragmento al índice y al árbol de trabajo\n"
+"n - no aplicar este fragmento al índice y al árbol de trabajo\n"
+"q - quit;  no aplicar este fragmento o ninguno de los restantes\n"
+"a - aplicar este fragmento y todos los posteriores en el archivo\n"
+"d - no aplicar este fragmento o ninguno de los siguientes en este archivo"
 
 #: git-add--interactive.perl:1311
 msgid ""
@@ -24398,19 +24398,19 @@ msgid ""
 "e - manually edit the current hunk\n"
 "? - print help\n"
 msgstr ""
-"g - selecciona un hunk a donde ir\n"
-"/ - buscar un hunk que concuerde el  regex\n"
-"j - dejar este hunk por definir, ver siguiente hunk por definir\n"
-"J - dejar este hunk por definir, ver siguiente hunk\n"
-"k - dejar este hunk por definir, ver hunk previo por definir\n"
-"K - dejar este hunk por definir, ver hunk previo\n"
+"g - selecciona un fragmento a donde ir\n"
+"/ - buscar un fragmento que concuerde el  regex\n"
+"j - dejar este fragmento por definir, ver siguiente hunk por definir\n"
+"J - dejar este fragmento por definir, ver siguiente hunk\n"
+"k - dejar este fragmento por definir, ver hunk previo por definir\n"
+"K - dejar este fragmento por definir, ver hunk previo\n"
 "s - dividir el  hunk actual en hunks más pequeños\n"
-"e - editar manualmente el hunk actual\n"
+"e - editar manualmente el fragmento actual\n"
 "? - imprimir ayuda\n"
 
 #: git-add--interactive.perl:1342
 msgid "The selected hunks do not apply to the index!\n"
-msgstr "¡Los hunks seleccionados no aplican al índice!\n"
+msgstr "¡Los fragmentos seleccionados no aplican al índice!\n"
 
 #: git-add--interactive.perl:1357
 #, perl-format
@@ -24430,16 +24430,16 @@ msgstr "¿Aplicar borrado al árbol de trabajo [y,n,q,a,d%s,?]? "
 #: git-add--interactive.perl:1470
 #, perl-format
 msgid "Apply this hunk to worktree [y,n,q,a,d%s,?]? "
-msgstr "¿Aplicar este hunk al árbol de trabajo [y,n,q,a,d,/%s,?]? "
+msgstr "¿Aplicar este fragmento al árbol de trabajo [y,n,q,a,d,/%s,?]? "
 
 #: git-add--interactive.perl:1570
 msgid "No other hunks to goto\n"
-msgstr "No hay más pedazos para el ir\n"
+msgstr "No hay más fragmentos hacia donde ir\n"
 
 #: git-add--interactive.perl:1588
 #, perl-format
 msgid "Invalid number: '%s'\n"
-msgstr "Numero inválido: '%s'\n"
+msgstr "Número inválido: '%s'\n"
 
 #: git-add--interactive.perl:1593
 #, perl-format
@@ -24450,7 +24450,7 @@ msgstr[1] "Lo siento, solo %d hunks disponibles.\n"
 
 #: git-add--interactive.perl:1619
 msgid "No other hunks to search\n"
-msgstr "No hay más pedazos para buscar\n"
+msgstr "No hay más fragmentos para buscar\n"
 
 #: git-add--interactive.perl:1636
 #, perl-format
@@ -24459,19 +24459,19 @@ msgstr "Regexp para la búsqueda mal formado %s: %s\n"
 
 #: git-add--interactive.perl:1646
 msgid "No hunk matches the given pattern\n"
-msgstr "No hay hunks que concuerden con el patrón entregado.\n"
+msgstr "No hay fragmentos que concuerden con el patrón entregado.\n"
 
 #: git-add--interactive.perl:1658 git-add--interactive.perl:1680
 msgid "No previous hunk\n"
-msgstr "No el anterior hunk\n"
+msgstr "No hay fragmento anterior\n"
 
 #: git-add--interactive.perl:1667 git-add--interactive.perl:1686
 msgid "No next hunk\n"
-msgstr "No el siguiente hunk\n"
+msgstr "No hay fragmento siguiente\n"
 
 #: git-add--interactive.perl:1692
 msgid "Sorry, cannot split this hunk\n"
-msgstr "Perdón, no se puede dividir este pedazo\n"
+msgstr "Perdón, no se puede dividir este fragmento\n"
 
 #: git-add--interactive.perl:1698
 #, perl-format
@@ -24482,7 +24482,7 @@ msgstr[1] "Cortar en  %d hunks.\n"
 
 #: git-add--interactive.perl:1708
 msgid "Sorry, cannot edit this hunk\n"
-msgstr "Perdón, no se puede editar este pedazo\n"
+msgstr "Perdón, no se puede editar este fragmento\n"
 
 #. TRANSLATORS: please do not translate the command names
 #. 'status', 'update', 'revert', etc.
@@ -24501,7 +24501,7 @@ msgstr ""
 "el área de stage\n"
 "revert        - revierte los cambios en el área de stage de regreso a la "
 "versión HEAD\n"
-"patch         - selecciona los hunks y actualiza de forma selectiva\n"
+"patch         - selecciona los fragmentos y actualiza de forma selectiva\n"
 "diff          - mirar la diff entre HEAD y el índice\n"
 "add untracked - agrega contenidos de archivos no rastreados al grupo de "
 "cambios del area de stage\n"
@@ -24576,7 +24576,7 @@ msgstr "Configuración --confirm desconocida: '%s'\n"
 #: git-send-email.perl:556
 #, perl-format
 msgid "warning: sendmail alias with quotes is not supported: %s\n"
-msgstr "peligro: alias de sendmail  con comillas no es soportado: %s\n"
+msgstr "peligro: alias de sendmail con comillas no es soportado: %s\n"
 
 #: git-send-email.perl:558
 #, perl-format
@@ -24620,7 +24620,7 @@ msgid ""
 "warning: no patches were sent\n"
 msgstr ""
 "fatal: %s: %s\n"
-"peligro: no se mandaron parches\n"
+"peligro: no se enviaron parches\n"
 
 #: git-send-email.perl:705
 msgid ""
@@ -24654,7 +24654,7 @@ msgstr ""
 "Considere incluir un diffstat global o una tabla de contenidos\n"
 "para el parche que estás escribiendo.\n"
 "\n"
-"Limpiar el contenido de body si no deseas mandar un resumen.\n"
+"Limpiar el contenido de body si no deseas enviar un resumen.\n"
 
 #: git-send-email.perl:763
 #, perl-format
@@ -24686,7 +24686,7 @@ msgstr ""
 
 #: git-send-email.perl:918
 msgid "Which 8bit encoding should I declare [UTF-8]? "
-msgstr "¿Que codificación de 8bit debería declarar [UTF-8]? "
+msgstr "¿Qué codificación de 8bit debería declarar [UTF-8]? "
 
 #: git-send-email.perl:926
 #, perl-format
@@ -24696,14 +24696,14 @@ msgid ""
 "has the template subject '*** SUBJECT HERE ***'. Pass --force if you really "
 "want to send.\n"
 msgstr ""
-"Rehusando mandar el parche porque\n"
+"Rehusando enviar el parche porque\n"
 "\t%s\n"
 "tiene el template  '*** SUBJECT HERE ***'. Agrega --force si realmente lo "
-"deseas mandar.\n"
+"deseas enviar.\n"
 
 #: git-send-email.perl:945
 msgid "To whom should the emails be sent (if anyone)?"
-msgstr "¿A quien se deben mandar los correos (si existe)?"
+msgstr "¿A quien se deben enviar los correos (si existe)?"
 
 #: git-send-email.perl:963
 #, perl-format
@@ -24726,7 +24726,7 @@ msgstr "error: no es posible extraer una dirección válida de %s\n"
 #. at this point.
 #: git-send-email.perl:1045
 msgid "What to do with this address? ([q]uit|[d]rop|[e]dit): "
-msgstr "¿Que hacer con esta dirección? ([q]salir|[d]botar|[e]ditar): "
+msgstr "¿Qué hacer con esta dirección? ([q]salir|[d]botar|[e]ditar): "
 
 #: git-send-email.perl:1362
 #, perl-format
@@ -24747,8 +24747,8 @@ msgid ""
 "\n"
 msgstr ""
 "    La lista Cc ha sido expandida por direcciones adicionales\n"
-"    encontradas en el mensaje de commit parchado.. Por defecto\n"
-"    send-email se muestra antes de mandar cualquier cada vez que esto "
+"    encontradas en el mensaje de commit parchado. Por defecto\n"
+"    send-email se muestra antes de enviar cada vez que esto "
 "sucede.\n"
 "    Este comportamiento is controlado por el valor de configuración "
 "sendemail.confirm.\n"
@@ -24767,11 +24767,11 @@ msgstr "¿Mandar este email? ([y]si||[n]o|[e]editar|[q]salir|[a]todo): "
 
 #: git-send-email.perl:1463
 msgid "Send this email reply required"
-msgstr "Necesitas mandar esta respuesta de email"
+msgstr "Necesitas enviar esta respuesta de email"
 
 #: git-send-email.perl:1491
 msgid "The required SMTP server is not properly defined."
-msgstr "El servidor SMTP no esta definido adecuadamente."
+msgstr "El servidor SMTP no está definido adecuadamente."
 
 #: git-send-email.perl:1538
 #, perl-format
@@ -24862,7 +24862,7 @@ msgstr "(%s) falló al cerrar el pipe para '%s'"
 
 #: git-send-email.perl:1905
 msgid "cannot send message as 7bit"
-msgstr "no se puede mandar mensaje como 7bit"
+msgstr "no se puede enviar mensaje como 7bit"
 
 #: git-send-email.perl:1913
 msgid "invalid transfer encoding"
@@ -24887,7 +24887,7 @@ msgstr "Saltando %s con el sufijo de backup '%s'.\n"
 #: git-send-email.perl:1978
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
-msgstr "¿Realmente deseas mandar %s?[y|N]: "
+msgstr "¿Realmente deseas enviar %s?[y|N]: "
 
 #, c-format
 #~ msgid ""
@@ -25026,13 +25026,13 @@ msgstr "¿Realmente deseas mandar %s?[y|N]: "
 
 #, c-format
 #~ msgid "Stage this hunk [y,n,a,q,d%s,?]? "
-#~ msgstr "¿Aplicar stage a este hunk [y,n,a,q,d%s,?]? "
+#~ msgstr "¿Aplicar stage a este fragmento [y,n,a,q,d%s,?]? "
 
 #~ msgid ""
 #~ "If the patch applies cleanly, the edited hunk will immediately be\n"
 #~ "marked for staging.\n"
 #~ msgstr ""
-#~ "Si el parche aplica limpiamente, el hunk editado sera marcado\n"
+#~ "Si el parche aplica limpiamente, el fragmento editado será marcado\n"
 #~ "inmediatamente para el área de stage.\n"
 
 #~ msgid ""
@@ -25042,11 +25042,11 @@ msgstr "¿Realmente deseas mandar %s?[y|N]: "
 #~ "a - stage this and all the remaining hunks\n"
 #~ "d - do not stage this hunk nor any of the remaining hunks\n"
 #~ msgstr ""
-#~ "y - aplicar stage a este hunk\n"
-#~ "n - no aplicar stage a este hunk\n"
-#~ "q - quit; no aplicar stage a este hunk o ninguno de los restantes\n"
-#~ "a - aplicar stage a este hunk y a todos los posteriores en el archivo \n"
-#~ "d - no aplicar stage a este hunk o a ninguno de los posteriores en este "
+#~ "y - aplicar stage a este fragmento\n"
+#~ "n - no aplicar stage a este fragmento\n"
+#~ "q - quit; no aplicar stage a este fragmento o ninguno de los restantes\n"
+#~ "a - aplicar stage a este fragmento y a todos los posteriores en el archivo \n"
+#~ "d - no aplicar stage a este fragmento o a ninguno de los posteriores en este "
 #~ "archivo\n"
 
 #, c-format
@@ -25248,7 +25248,7 @@ msgstr "¿Realmente deseas mandar %s?[y|N]: "
 #~ msgstr "No se pudo crear el directorio '%s'"
 
 #~ msgid "allow rerere to update index with resolved conflict"
-#~ msgstr "permitir rerere actualizar index con conflictos resueltos"
+#~ msgstr "permitir rerere actualizar índice con conflictos resueltos"
 
 #~ msgid "could not open %s"
 #~ msgstr "no se pudo abrir %s"
@@ -25517,7 +25517,7 @@ msgstr "¿Realmente deseas mandar %s?[y|N]: "
 #~ "       To provide a message, use git stash save -- '$option'"
 #~ msgstr ""
 #~ "error: opción desconocida para 'stash save': $option\n"
-#~ "       Esto provee un mensaje , use git stash save -- '$option'"
+#~ "       Esto provee un mensaje, use git stash save -- '$option'"
 
 #~ msgid "Failed to recurse into submodule path '$sm_path'"
 #~ msgstr "Falló al recurrir en la ruta de submódulo '$sm_path'"


### PR DESCRIPTION
Some changes are wording and syntax fixes, and other are improvements about consistency:
- Removed extra blank spaces;
- Add missing tildes;
- Translated some missing words;
- Replaced some words in order to use more neutral terms.

Signed-off-by: Javier Spagnoletti phansys@gmail.com