### PR TITLE
Improve spanish translation, changed es.po

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -5744,8 +5744,8 @@ msgid ""
 "Warning: some commits may have been dropped accidentally.\n"
 "Dropped commits (newer to older):\n"
 msgstr ""
-"Peligro: algunos commits pueden haber sido botados de forma accidental.\n"
-"Commits botados (empezando con el más nuevo):\n"
+"Peligro: algunos commits pueden haber sido descartados de forma accidental.\n"
+"Commits descartados (empezando con el más nuevo):\n"
 
 #: rebase-interactive.c:200
 #, c-format
@@ -7000,7 +7000,7 @@ msgstr "no se pudo aplicar %s... %s"
 #: sequencer.c:1972
 #, c-format
 msgid "dropping %s %s -- patch contents already upstream\n"
-msgstr "botando $%s %s -- contenidos del parche ya están en upstream\n"
+msgstr "descartando $%s %s -- contenidos del parche ya están en upstream\n"
 
 #: sequencer.c:2030
 #, c-format
@@ -20781,7 +20781,7 @@ msgstr "intento de recrear el index"
 #: builtin/stash.c:555
 #, c-format
 msgid "Dropped %s (%s)"
-msgstr "Botado %s (%s)"
+msgstr "Descartado %s (%s)"
 
 #: builtin/stash.c:558
 #, c-format
@@ -24726,7 +24726,7 @@ msgstr "error: no es posible extraer una dirección válida de %s\n"
 #. at this point.
 #: git-send-email.perl:1045
 msgid "What to do with this address? ([q]uit|[d]rop|[e]dit): "
-msgstr "¿Que hacer con esta dirección? ([q]salir|[d]botar|[e]ditar): "
+msgstr "¿Que hacer con esta dirección? ([q]salir|[d]escartar|[e]ditar): "
 
 #: git-send-email.perl:1362
 #, perl-format


### PR DESCRIPTION
This change get a translation in Spanish more international and accurate.
Change: botar -> descartar (drop) link: [RAE](https://dle.rae.es/botar)
Signed-off-by: Jose Miguel Lopez <josmilope+github@gmail.com>
